### PR TITLE
Potential fix for code scanning alert no. 1: Unused import

### DIFF
--- a/src/athena_mcp/tools/query.py
+++ b/src/athena_mcp/tools/query.py
@@ -5,7 +5,7 @@ Simple tools for executing queries and getting results.
 """
 
 import json
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from ..athena import AthenaClient, AthenaError
 from ..models import QueryRequest, QueryResult


### PR DESCRIPTION
Potential fix for [https://github.com/ColeMurray/aws-athena-mcp/security/code-scanning/1](https://github.com/ColeMurray/aws-athena-mcp/security/code-scanning/1)

To fix the problem, the unused `Union` import should be removed from the file. This involves editing the import statement on line 8 to exclude `Union`. Removing the unused import will not affect the functionality of the code, as `Union` is not referenced anywhere in the provided snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
