### PR TITLE
Feature: Add search term capabilities to list_tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Enhanced schema discovery tools with search functionality
+  - `list_tables` now supports optional `search` parameter for filtering table names
+  - Improved error handling with structured JSON responses for schema tools
 - Comprehensive test suite for configuration module
 - Type annotations throughout codebase
 - Security policy and vulnerability reporting process
@@ -15,8 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MIT license for open source distribution
 
 ### Changed
+- Updated API documentation to reflect current schema tools implementation
+- Enhanced data models documentation with `DatabaseInfo` and `TableInfo` structures
 - Improved error message consistency in configuration validation
 - Enhanced documentation with security best practices
+
+### Documentation
+- Updated API reference to include search parameter for `list_tables`
+- Added comprehensive data models documentation
+- Enhanced usage examples for schema discovery tools
+- Updated README with current tool capabilities
 
 ### Security
 - Added input validation for all query parameters

--- a/README.md
+++ b/README.md
@@ -357,8 +357,8 @@ The server provides these MCP tools:
 
 ### Schema Discovery
 
-- **`list_tables`** - List all tables in a database
-- **`describe_table`** - Get detailed table schema
+- **`list_tables`** - List all tables in a database (with optional search filtering)
+- **`describe_table`** - Get detailed table schema information
 
 ## 📖 Usage Examples
 
@@ -376,15 +376,21 @@ result = await mcp_client.call_tool("run_query", {
 ### Schema Discovery
 
 ```python
-# List tables
+# List all tables in a database
 tables = await mcp_client.call_tool("list_tables", {
     "database": "default"
 })
 
-# Describe a table
+# List tables with search filter
+user_tables = await mcp_client.call_tool("list_tables", {
+    "database": "default",
+    "search": "user"
+})
+
+# Describe a specific table
 schema = await mcp_client.call_tool("describe_table", {
     "database": "default",
-    "table_name": "my_table"
+    "table_name": "user_events"
 })
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -66,18 +66,27 @@ Retrieve results for a completed query.
 
 ### `list_tables`
 
-List all tables in a specified database.
+List all tables in a specified database with optional search filtering.
 
 **Parameters:**
 - `database` (string, required): The Athena database name
+- `search` (string, optional): Optional search string to filter table names
 
 **Returns:**
-- JSON string containing an array of table names
+- JSON string containing a `DatabaseInfo` object with table information
 
 **Example:**
 ```json
 {
   "database": "default"
+}
+```
+
+**Example with search filter:**
+```json
+{
+  "database": "analytics",
+  "search": "user"
 }
 ```
 
@@ -90,7 +99,7 @@ Get detailed schema information for a specific table.
 - `table_name` (string, required): The name of the table to describe
 
 **Returns:**
-- JSON string containing table schema details including column names, types, and comments
+- JSON string containing a `TableInfo` object with detailed table schema
 
 **Example:**
 ```json
@@ -109,27 +118,68 @@ The `QueryResult` object returned by successful queries contains:
 ```json
 {
   "query_execution_id": "string",
-  "query": "string",
-  "database": "string",
-  "state": "string",
+  "columns": ["col1", "col2", "..."],
+  "rows": [
+    {"col1": "value1", "col2": "value2", "..."}
+  ],
+  "bytes_scanned": 0,
+  "execution_time_ms": 0
+}
+```
+
+### QueryStatus
+
+The `QueryStatus` object returned by status checks contains:
+
+```json
+{
+  "query_execution_id": "string",
+  "state": "QUEUED|RUNNING|SUCCEEDED|FAILED|CANCELLED",
   "state_change_reason": "string",
-  "submission_date_time": "datetime",
-  "completion_date_time": "datetime",
-  "data_scanned_in_bytes": "integer",
-  "execution_time_in_millis": "integer",
-  "result_configuration": {
-    "output_location": "string"
-  },
+  "bytes_scanned": 0,
+  "execution_time_ms": 0
+}
+```
+
+### DatabaseInfo
+
+The `DatabaseInfo` object returned by `list_tables` contains:
+
+```json
+{
+  "database": "string",
+  "tables": ["table1", "table2", "..."],
+  "table_count": 0
+}
+```
+
+### TableInfo
+
+The `TableInfo` object returned by `describe_table` contains:
+
+```json
+{
+  "database": "string",
+  "table_name": "string",
   "columns": [
     {
       "name": "string",
-      "type": "string"
+      "type": "string",
+      "comment": "string"
     }
-  ],
-  "rows": [
-    ["value1", "value2", "..."]
-  ],
-  "row_count": "integer"
+  ]
+}
+```
+
+### ErrorResponse
+
+Error responses follow this standard format:
+
+```json
+{
+  "error": "string",
+  "code": "string",
+  "query_execution_id": "string"
 }
 ```
 
@@ -141,8 +191,9 @@ All tools may return error messages in case of failures:
 - **AWS credential errors**: Invalid or insufficient AWS permissions
 - **Query errors**: SQL syntax errors or execution failures
 - **Timeout errors**: Queries that exceed the configured timeout
+- **Validation errors**: Invalid database or table names
 
-Error responses are returned as descriptive string messages explaining the issue and potential solutions.
+Error responses are returned as JSON objects with descriptive error messages and error codes.
 
 ## Rate Limits and Quotas
 
@@ -152,5 +203,6 @@ Be aware of AWS Athena service limits:
 - **Query timeout**: Configurable via `ATHENA_TIMEOUT_SECONDS` (default: 60 seconds)
 - **Result size**: Large result sets may be truncated based on `max_rows` parameter
 - **S3 permissions**: Ensure proper permissions for the output location
+- **Glue API limits**: Schema discovery tools use AWS Glue APIs which have their own rate limits
 
-For more information, see the [AWS Athena Service Quotas](https://docs.aws.amazon.com/athena/latest/ug/service-limits.html) documentation. 
+For more information, see the [AWS Athena Service Quotas](https://docs.aws.amazon.com/athena/latest/ug/service-limits.html) and [AWS Glue Service Quotas](https://docs.aws.amazon.com/glue/latest/dg/service-limits.html) documentation. 

--- a/src/athena_mcp/athena.py
+++ b/src/athena_mcp/athena.py
@@ -261,13 +261,18 @@ class AthenaClient:
             logger.error(f"Error getting query results: {error_code} - {str(e)}")
             raise AthenaError(str(e), error_code, query_execution_id)
 
-    async def list_tables(self, database: str) -> DatabaseInfo:
+    async def list_tables(self, database: str, search: Optional[str] = None) -> DatabaseInfo:
         """List all tables in a database."""
         logger.info(f"Listing tables in database: {database}")
 
         sanitized_database = QueryValidator.sanitize_identifier(database)
 
-        request = QueryRequest(database=sanitized_database, query="SHOW TABLES", max_rows=1000)
+        if search:
+            search_str = f"LIKE '*{search.lower()}*'"
+        else:
+            search_str = ""
+
+        request = QueryRequest(database=sanitized_database, query=f"SHOW TABLES {search_str}", max_rows=1000)
 
         result = await self.execute_query(request)
 

--- a/src/athena_mcp/tools/schema.py
+++ b/src/athena_mcp/tools/schema.py
@@ -5,7 +5,7 @@ Simple tools for discovering database and table schemas.
 """
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from ..athena import AthenaClient, AthenaError
 
@@ -17,12 +17,13 @@ def register_schema_tools(mcp: "FastMCP", athena_client: AthenaClient) -> None:
     """Register schema-related MCP tools."""
 
     @mcp.tool()
-    async def list_tables(database: str) -> str:
+    async def list_tables(database: str, search: Optional[str] = None) -> str:
         """
         List all tables in the specified Athena database.
 
         Args:
             database: The Athena database to list tables from
+            search: Optional search string to filter tables
 
         Returns:
             JSON string with list of tables
@@ -31,7 +32,7 @@ def register_schema_tools(mcp: "FastMCP", athena_client: AthenaClient) -> None:
             if not database.strip():
                 raise ValueError("Database name cannot be empty")
 
-            database_info = await athena_client.list_tables(database)
+            database_info = await athena_client.list_tables(database, search)
             return json.dumps(database_info.dict(), indent=2)
 
         except AthenaError as e:


### PR DESCRIPTION
## Description

Adds a search parameter to the `list_tables` tool, which allows a more efficient discovery of tables in large databases. 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🔒 Security enhancement
- [ ] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## Related Issues

<!-- Link to related issues using "Fixes #123" or "Closes #123" -->

Fixes #(issue_number)

## Changes Made

- Added optional `search` parameter to `list_tables` for filtering table names
- Updated API and README documentation to reflect new schema tool capabilities
- Added comprehensive tests for schema tools, including search, error handling, and sanitization
- Improved data model documentation and usage examples

## Testing

<!-- Describe the tests you ran to verify your changes -->

### Test Environment
- OS: MacOS
- Python version: 3.13
- AWS region: us-east-1

### Tests Run
- [x] All existing tests pass (`pytest tests/ -v`)
- [x] New tests added for new functionality
- [x] Manual testing performed
- [ ] Security testing (if applicable)

### Test Results
```bash
tests/test_athena_client.py::TestQueryValidator::test_validate_query_success PASSED                                             [  3%]
tests/test_athena_client.py::TestQueryValidator::test_validate_query_empty PASSED                                               [  6%]
tests/test_athena_client.py::TestQueryValidator::test_validate_query_dangerous_patterns PASSED                                  [  9%]
tests/test_athena_client.py::TestQueryValidator::test_validate_query_too_large PASSED                                           [ 12%]
tests/test_athena_client.py::TestQueryValidator::test_sanitize_identifier_success PASSED                                        [ 15%]
tests/test_athena_client.py::TestQueryValidator::test_sanitize_identifier_empty PASSED                                          [ 18%]
tests/test_athena_client.py::TestQueryValidator::test_sanitize_identifier_invalid_chars PASSED                                  [ 21%]
tests/test_athena_client.py::TestQueryValidator::test_sanitize_identifier_too_long PASSED                                       [ 24%]
tests/test_athena_client.py::TestAthenaClient::test_athena_client_init PASSED                                                   [ 27%]
tests/test_athena_client.py::TestAthenaClient::test_execute_query_success PASSED                                                [ 30%]
tests/test_athena_client.py::TestAthenaClient::test_execute_query_timeout PASSED                                                [ 33%]
tests/test_athena_client.py::TestAthenaClient::test_execute_query_validation_error PASSED                                       [ 36%]
tests/test_athena_client.py::TestAthenaClient::test_get_query_status PASSED                                                     [ 39%]
tests/test_athena_client.py::TestAthenaClient::test_list_tables PASSED                                                          [ 42%]
tests/test_athena_client.py::TestAthenaClient::test_list_tables_with_search PASSED                                              [ 45%]
tests/test_athena_client.py::TestAthenaClient::test_list_tables_empty_database PASSED                                           [ 48%]
tests/test_athena_client.py::TestAthenaClient::test_list_tables_timeout PASSED                                                  [ 51%]
tests/test_athena_client.py::TestAthenaClient::test_list_tables_invalid_database PASSED                                         [ 54%]
tests/test_athena_client.py::TestAthenaClient::test_list_tables_aws_error PASSED                                                [ 57%]
tests/test_athena_client.py::TestAthenaClient::test_describe_table PASSED                                                       [ 60%]
tests/test_athena_client.py::TestAthenaClient::test_describe_table_complex_schema PASSED                                        [ 63%]
tests/test_athena_client.py::TestAthenaClient::test_describe_table_timeout PASSED                                               [ 66%]
tests/test_athena_client.py::TestAthenaClient::test_describe_table_invalid_parameters PASSED                                    [ 69%]
tests/test_athena_client.py::TestAthenaClient::test_describe_table_aws_error PASSED                                             [ 72%]
tests/test_athena_client.py::TestAthenaClient::test_describe_table_empty_schema PASSED                                          [ 75%]
tests/test_athena_client.py::TestAthenaClient::test_schema_tools_sanitization PASSED                                            [ 78%]
tests/test_config.py::TestConfig::test_from_env_success PASSED                                                                  [ 81%]
tests/test_config.py::TestConfig::test_from_env_defaults PASSED                                                                 [ 84%]
tests/test_config.py::TestConfig::test_missing_required_env_var PASSED                                                          [ 87%]
tests/test_config.py::TestConfig::test_invalid_s3_path PASSED                                                                   [ 90%]
tests/test_config.py::TestConfig::test_invalid_timeout PASSED                                                                   [ 93%]
tests/test_config.py::TestConfig::test_zero_timeout PASSED                                                                      [ 96%]
tests/test_config.py::TestConfig::test_str_representation PASSED                                                                [100%]

========================================================= 33 passed in 3.30s ==========================================================
```

## Security Considerations

<!-- If this PR has security implications, describe them -->

- [ ] No security implications
- [ ] Security review required
- [ ] Sensitive data handling reviewed
- [ ] Input validation added/updated
- [ ] Authentication/authorization changes

## Documentation

<!-- Check all that apply -->

- [ ] Code is self-documenting with clear variable/function names
- [ ] Docstrings added/updated for new functions/classes
- [x] README.md updated (if needed)
- [x] CHANGELOG.md updated
- [ ] Type hints added for new code

## Code Quality

<!-- Confirm code quality standards are met -->

- [ ] Code follows project style guidelines
- [ ] Code has been formatted with `black`
- [ ] Imports sorted with `isort`
- [ ] Type checking passes with `mypy`
- [ ] No new linting errors introduced
- [ ] Code is properly commented

## Backwards Compatibility

<!-- Describe any backwards compatibility considerations -->

- [ ] This change is backwards compatible
- [ ] This change requires version bump (major/minor/patch)
- [ ] Migration guide needed (if breaking change)

## Performance Impact

<!-- Describe any performance implications -->

- [ ] No performance impact
- [ ] Performance improvement
- [ ] Potential performance regression (explain below)

## Deployment Notes

<!-- Any special deployment considerations -->

- [ ] No special deployment requirements
- [ ] Environment variables added/changed
- [ ] Dependencies added/updated
- [ ] Database changes required
- [ ] Configuration changes required

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples -->

```python
# Example usage of new feature
```

## Checklist

<!-- Ensure all items are checked before submitting -->

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information that reviewers should know --> 