### PR TITLE
Fix first table omitted from SHOW TABLES results

### DIFF
--- a/src/athena_mcp/athena.py
+++ b/src/athena_mcp/athena.py
@@ -184,6 +184,7 @@ class AthenaClient:
             query_status = QueryStatus(
                 query_execution_id=query_execution_id,
                 state=QueryState(status.get("State", "UNKNOWN")),
+                statement_type=execution.get("StatementType"),
                 state_change_reason=status.get("StateChangeReason"),
                 bytes_scanned=statistics.get("DataScannedInBytes", 0),
                 execution_time_ms=statistics.get("EngineExecutionTimeInMillis", 0),
@@ -232,9 +233,9 @@ class AthenaClient:
             column_info = result_set.get("ResultSetMetadata", {}).get("ColumnInfo", [])
             columns = [col.get("Name", "") for col in column_info]
 
-            # Extract rows (skip header for SELECT queries)
+            # DML results include a header row; utility results start with data.
             rows_data = result_set.get("Rows", [])
-            start_index = 1 if len(rows_data) > 0 and columns else 0
+            start_index = 1 if rows_data and columns and status.statement_type == "DML" else 0
 
             rows = []
             for row_data in rows_data[start_index:]:

--- a/src/athena_mcp/models.py
+++ b/src/athena_mcp/models.py
@@ -43,6 +43,7 @@ class QueryStatus(BaseModel):
 
     query_execution_id: str
     state: QueryState
+    statement_type: Optional[str] = None
     state_change_reason: Optional[str] = None
     bytes_scanned: int = 0
     execution_time_ms: int = 0

--- a/tests/test_athena_client.py
+++ b/tests/test_athena_client.py
@@ -134,6 +134,7 @@ class TestAthenaClient:
 
         mock_boto3_client.get_query_execution.return_value = {
             "QueryExecution": {
+                "StatementType": "DML",
                 "Status": {"State": "SUCCEEDED"},
                 "Statistics": {"DataScannedInBytes": 1024, "EngineExecutionTimeInMillis": 5000},
             }
@@ -205,6 +206,7 @@ class TestAthenaClient:
         """Test getting query status."""
         mock_boto3_client.get_query_execution.return_value = {
             "QueryExecution": {
+                "StatementType": "DML",
                 "Status": {
                     "State": "SUCCEEDED",
                     "StateChangeReason": "Query completed successfully",
@@ -218,6 +220,7 @@ class TestAthenaClient:
 
         assert status.query_execution_id == "test-execution-id"
         assert status.state == QueryState.SUCCEEDED
+        assert status.statement_type == "DML"
         assert status.bytes_scanned == 2048
         assert status.execution_time_ms == 3000
 
@@ -230,14 +233,17 @@ class TestAthenaClient:
         }
 
         mock_boto3_client.get_query_execution.return_value = {
-            "QueryExecution": {"Status": {"State": "SUCCEEDED"}, "Statistics": {}}
+            "QueryExecution": {
+                "StatementType": "UTILITY",
+                "Status": {"State": "SUCCEEDED"},
+                "Statistics": {},
+            }
         }
 
         mock_boto3_client.get_query_results.return_value = {
             "ResultSet": {
                 "ResultSetMetadata": {"ColumnInfo": [{"Name": "tab_name"}]},
                 "Rows": [
-                    {"Data": [{"VarCharValue": "tab_name"}]},  # Header
                     {"Data": [{"VarCharValue": "table1"}]},
                     {"Data": [{"VarCharValue": "table2"}]},
                 ],
@@ -249,8 +255,7 @@ class TestAthenaClient:
 
         assert database_info.database == "test_db"
         assert database_info.table_count == 2
-        assert "table1" in database_info.tables
-        assert "table2" in database_info.tables
+        assert database_info.tables == ["table1", "table2"]
 
     @pytest.mark.asyncio
     async def test_describe_table(self, config, mock_boto3_client):
@@ -261,7 +266,11 @@ class TestAthenaClient:
         }
 
         mock_boto3_client.get_query_execution.return_value = {
-            "QueryExecution": {"Status": {"State": "SUCCEEDED"}, "Statistics": {}}
+            "QueryExecution": {
+                "StatementType": "UTILITY",
+                "Status": {"State": "SUCCEEDED"},
+                "Statistics": {},
+            }
         }
 
         mock_boto3_client.get_query_results.return_value = {
@@ -270,13 +279,6 @@ class TestAthenaClient:
                     "ColumnInfo": [{"Name": "col_name"}, {"Name": "data_type"}, {"Name": "comment"}]
                 },
                 "Rows": [
-                    {
-                        "Data": [
-                            {"VarCharValue": "col_name"},
-                            {"VarCharValue": "data_type"},
-                            {"VarCharValue": "comment"},
-                        ]
-                    },  # Header
                     {
                         "Data": [
                             {"VarCharValue": "id"},


### PR DESCRIPTION
## Summary
- retain the Athena statement type when reading query status
- skip the result header only for DML statements
- update `SHOW TABLES` and `DESCRIBE` tests to use Athena's headerless utility-result shape
- preserve existing header handling for `SELECT` queries

Fixes #48.

## Verification
- `uv run --extra dev pytest` (22 passed)
- `uv run --extra dev black --check src tests`
- `uv run --extra dev isort --check-only src tests`
- `uv run --extra dev mypy src`
- `uv build`

The repository does not contain integration tests, so no live AWS integration suite was available to run.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/d007bda93c4f5c9d89d45b2133aa4894)*