### PR TITLE
Upgrade FastMCP to 3.2.0 with compatibility coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "fastmcp==2.5.2",
+    "fastmcp==3.2.0",
     "boto3>=1.34.0,<2.0.0",
     "pydantic>=2.5.0,<3.0.0",
 ]
@@ -128,4 +128,4 @@ exclude_lines = [
     "if __name__ == .__main__.:",
     "class .*\\bProtocol\\):",
     "@(abc\\.)?abstractmethod",
-] 
+]

--- a/tests/test_fastmcp_compatibility.py
+++ b/tests/test_fastmcp_compatibility.py
@@ -1,0 +1,40 @@
+"""FastMCP compatibility tests for the server's public tool contract."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from athena_mcp.athena import AthenaClient
+from athena_mcp.tools import register_query_tools, register_schema_tools
+
+
+@pytest.fixture
+def mcp_server() -> FastMCP:
+    """Create the MCP server without requiring AWS configuration or credentials."""
+    server = FastMCP(name="aws-athena-mcp", version="1.0.0")
+    athena_client = MagicMock(spec=AthenaClient)
+    register_query_tools(server, athena_client)
+    register_schema_tools(server, athena_client)
+    return server
+
+
+async def test_tools_are_discoverable_and_callable(mcp_server: FastMCP) -> None:
+    """Verify the FastMCP APIs used by the server work through an MCP client."""
+    async with Client(mcp_server) as client:
+        tools = await client.list_tools()
+        result = await client.call_tool("run_query", {"database": "", "query": "SELECT 1"})
+
+    assert {tool.name for tool in tools} == {
+        "run_query",
+        "get_status",
+        "get_result",
+        "list_tables",
+        "describe_table",
+    }
+    assert not result.is_error
+    assert json.loads(result.content[0].text) == {
+        "error": "Database name cannot be empty",
+        "code": "INVALID_REQUEST",
+    }


### PR DESCRIPTION
## Summary

- upgrade the pinned FastMCP dependency from 2.5.2 to 3.2.0
- add an in-process MCP compatibility test covering server construction, discovery of all five tools, and tool dispatch/result serialization
- normalize the existing trailing whitespace at the end of `pyproject.toml`

## Compatibility investigation

FastMCP was pinned to 2.5.2 in commit `125c4a7` after FastMCP 2.6.0 omitted its `py.typed` marker. That upstream packaging regression caused mypy to report FastMCP as an untyped import; it was not a runtime API incompatibility.

FastMCP 3.2.0 includes `py.typed`, passes strict mypy without `--ignore-missing-imports`, and supports the APIs this project uses: `FastMCP(...)`, `@mcp.tool()`, in-process tool discovery/dispatch, and the stdio run interface.

## Validation

- 23 tests pass on Python 3.11
- 23 tests pass on Python 3.12
- strict mypy passes without `--ignore-missing-imports`
- Black and isort checks pass
- `pip check` passes
- package build and `twine check` pass
- FastMCP 3.2.0 wheel contains `py.typed`

Python 3.10 remains covered by the repository CI matrix.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/64264f28185d6cbffa98ab086541ca5a)*